### PR TITLE
openssl: do not install docs

### DIFF
--- a/Formula/openssl-static.rb
+++ b/Formula/openssl-static.rb
@@ -108,7 +108,7 @@ class OpensslStatic < Formula
     openssldir.mkpath
     system "perl", "./Configure", *(configure_args + arch_args)
     system "make"
-    system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
+    system "make", "install_sw", "MANDIR=#{man}", "MANSUFFIX=ssl"
     system "make", "test"
   end
 


### PR DESCRIPTION
Not needed, and the installation is much faster w/o installing the manual.